### PR TITLE
Feature/issue 88

### DIFF
--- a/rtfs_compiler/examples/intent_generation_demo.rs
+++ b/rtfs_compiler/examples/intent_generation_demo.rs
@@ -410,7 +410,7 @@ COMMON PATTERNS:
     let capability_marketplace = std::sync::Arc::new(rtfs_compiler::runtime::capability_marketplace::CapabilityMarketplace::new(registry.clone()));
 
     // Evaluator (we won't actually evaluate the generated intent here, but set up for future)
-    let host = Rc::new(rtfs_compiler::runtime::host::RuntimeHost::new(
+    let host = std::sync::Arc::new(rtfs_compiler::runtime::host::RuntimeHost::new(
         Arc::new(std::sync::Mutex::new(rtfs_compiler::ccos::causal_chain::CausalChain::new().unwrap())),
         capability_marketplace,
         rtfs_compiler::runtime::security::RuntimeContext::pure(),

--- a/rtfs_compiler/examples/plan_generation_demo.rs
+++ b/rtfs_compiler/examples/plan_generation_demo.rs
@@ -146,7 +146,7 @@ fn test_capability_system() -> Result<(), Box<dyn std::error::Error>> {
     let stdlib_env = StandardLibrary::create_global_environment();
     let registry = std::sync::Arc::new(tokio::sync::RwLock::new(rtfs_compiler::runtime::capability_registry::CapabilityRegistry::new()));
     let capability_marketplace = std::sync::Arc::new(rtfs_compiler::runtime::capability_marketplace::CapabilityMarketplace::new(registry.clone()));
-    let host = Rc::new(rtfs_compiler::runtime::host::RuntimeHost::new(
+    let host = std::sync::Arc::new(rtfs_compiler::runtime::host::RuntimeHost::new(
         Arc::new(std::sync::Mutex::new(rtfs_compiler::ccos::causal_chain::CausalChain::new().unwrap())),
         capability_marketplace,
         pure_context.clone(),
@@ -184,7 +184,7 @@ fn test_capability_system() -> Result<(), Box<dyn std::error::Error>> {
     let stdlib_env = StandardLibrary::create_global_environment();
     let registry = std::sync::Arc::new(tokio::sync::RwLock::new(rtfs_compiler::runtime::capability_registry::CapabilityRegistry::new()));
     let capability_marketplace = std::sync::Arc::new(rtfs_compiler::runtime::capability_marketplace::CapabilityMarketplace::new(registry.clone()));
-    let host = Rc::new(rtfs_compiler::runtime::host::RuntimeHost::new(
+    let host = std::sync::Arc::new(rtfs_compiler::runtime::host::RuntimeHost::new(
         Arc::new(std::sync::Mutex::new(rtfs_compiler::ccos::causal_chain::CausalChain::new().unwrap())),
         capability_marketplace,
         controlled_context.clone(),
@@ -223,7 +223,7 @@ fn test_capability_system() -> Result<(), Box<dyn std::error::Error>> {
     let stdlib_env = StandardLibrary::create_global_environment();
     let registry = std::sync::Arc::new(tokio::sync::RwLock::new(rtfs_compiler::runtime::capability_registry::CapabilityRegistry::new()));
     let capability_marketplace = std::sync::Arc::new(rtfs_compiler::runtime::capability_marketplace::CapabilityMarketplace::new(registry.clone()));
-    let host = Rc::new(rtfs_compiler::runtime::host::RuntimeHost::new(
+    let host = std::sync::Arc::new(rtfs_compiler::runtime::host::RuntimeHost::new(
         Arc::new(std::sync::Mutex::new(rtfs_compiler::ccos::causal_chain::CausalChain::new().unwrap())),
         capability_marketplace,
         full_context.clone(),
@@ -270,7 +270,7 @@ fn test_capability_system() -> Result<(), Box<dyn std::error::Error>> {
     let stdlib_env = StandardLibrary::create_global_environment();
     let registry = std::sync::Arc::new(tokio::sync::RwLock::new(rtfs_compiler::runtime::capability_registry::CapabilityRegistry::new()));
     let capability_marketplace = std::sync::Arc::new(rtfs_compiler::runtime::capability_marketplace::CapabilityMarketplace::new(registry.clone()));
-    let host = Rc::new(rtfs_compiler::runtime::host::RuntimeHost::new(
+    let host = std::sync::Arc::new(rtfs_compiler::runtime::host::RuntimeHost::new(
         Arc::new(std::sync::Mutex::new(rtfs_compiler::ccos::causal_chain::CausalChain::new().unwrap())),
         capability_marketplace,
         math_context.clone(),
@@ -321,7 +321,7 @@ fn test_capability_system() -> Result<(), Box<dyn std::error::Error>> {
     let stdlib_env = StandardLibrary::create_global_environment();
     let registry = std::sync::Arc::new(tokio::sync::RwLock::new(rtfs_compiler::runtime::capability_registry::CapabilityRegistry::new()));
     let capability_marketplace = std::sync::Arc::new(rtfs_compiler::runtime::capability_marketplace::CapabilityMarketplace::new(registry.clone()));
-    let host = Rc::new(rtfs_compiler::runtime::host::RuntimeHost::new(
+    let host = std::sync::Arc::new(rtfs_compiler::runtime::host::RuntimeHost::new(
         Arc::new(std::sync::Mutex::new(rtfs_compiler::ccos::causal_chain::CausalChain::new().unwrap())),
         capability_marketplace,
         plan_context.clone(),
@@ -517,7 +517,7 @@ GENERATED RTFS PLAN:
     let stdlib_env = StandardLibrary::create_global_environment();
     let registry = std::sync::Arc::new(tokio::sync::RwLock::new(rtfs_compiler::runtime::capability_registry::CapabilityRegistry::new()));
     let capability_marketplace = std::sync::Arc::new(rtfs_compiler::runtime::capability_marketplace::CapabilityMarketplace::new(registry.clone()));
-    let host = Rc::new(rtfs_compiler::runtime::host::RuntimeHost::new(
+    let host = std::sync::Arc::new(rtfs_compiler::runtime::host::RuntimeHost::new(
         Arc::new(std::sync::Mutex::new(rtfs_compiler::ccos::causal_chain::CausalChain::new().unwrap())),
         capability_marketplace,
         rtfs_compiler::runtime::security::RuntimeContext::full(),

--- a/rtfs_compiler/examples/realistic_model_example.rs
+++ b/rtfs_compiler/examples/realistic_model_example.rs
@@ -56,7 +56,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let module_registry = Rc::new(ModuleRegistry::new());
     let registry = std::sync::Arc::new(tokio::sync::RwLock::new(rtfs_compiler::runtime::capability_registry::CapabilityRegistry::new()));
     let capability_marketplace = std::sync::Arc::new(rtfs_compiler::runtime::capability_marketplace::CapabilityMarketplace::new(registry.clone()));
-    let host = Rc::new(rtfs_compiler::runtime::host::RuntimeHost::new(
+    let host = std::sync::Arc::new(rtfs_compiler::runtime::host::RuntimeHost::new(
         Arc::new(std::sync::Mutex::new(rtfs_compiler::ccos::causal_chain::CausalChain::new().unwrap())),
         capability_marketplace,
         rtfs_compiler::runtime::security::RuntimeContext::pure(),

--- a/rtfs_compiler/examples/remote_model_example.rs
+++ b/rtfs_compiler/examples/remote_model_example.rs
@@ -119,7 +119,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let module_registry = Rc::new(ModuleRegistry::new());
     let registry = std::sync::Arc::new(tokio::sync::RwLock::new(rtfs_compiler::runtime::capability_registry::CapabilityRegistry::new()));
     let capability_marketplace = std::sync::Arc::new(rtfs_compiler::runtime::capability_marketplace::CapabilityMarketplace::new(registry.clone()));
-    let host = Rc::new(rtfs_compiler::runtime::host::RuntimeHost::new(
+    let host = std::sync::Arc::new(rtfs_compiler::runtime::host::RuntimeHost::new(
         Arc::new(std::sync::Mutex::new(rtfs_compiler::ccos::causal_chain::CausalChain::new().unwrap())),
         capability_marketplace,
         rtfs_compiler::runtime::security::RuntimeContext::pure(),

--- a/rtfs_compiler/examples/run_plan.rs
+++ b/rtfs_compiler/examples/run_plan.rs
@@ -98,7 +98,7 @@ pub fn run_plan_with_full_security_context(plan_path: &str) -> Result<(), Box<dy
             let stdlib_env = StandardLibrary::create_global_environment();
             let registry = std::sync::Arc::new(tokio::sync::RwLock::new(rtfs_compiler::runtime::capability_registry::CapabilityRegistry::new()));
             let capability_marketplace = std::sync::Arc::new(rtfs_compiler::runtime::capability_marketplace::CapabilityMarketplace::new(registry.clone()));
-            let host = Rc::new(rtfs_compiler::runtime::host::RuntimeHost::new(
+            let host = std::sync::Arc::new(rtfs_compiler::runtime::host::RuntimeHost::new(
                 Arc::new(std::sync::Mutex::new(rtfs_compiler::ccos::causal_chain::CausalChain::new().unwrap())),
                 capability_marketplace,
                 rtfs_compiler::runtime::security::RuntimeContext::full(),

--- a/rtfs_compiler/examples/smart_dependency_updater.rs
+++ b/rtfs_compiler/examples/smart_dependency_updater.rs
@@ -121,7 +121,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let module_registry = Rc::new(ModuleRegistry::new());
     let registry = std::sync::Arc::new(tokio::sync::RwLock::new(rtfs_compiler::runtime::capability_registry::CapabilityRegistry::new()));
     let capability_marketplace = std::sync::Arc::new(rtfs_compiler::runtime::capability_marketplace::CapabilityMarketplace::new(registry.clone()));
-    let host = Rc::new(rtfs_compiler::runtime::host::RuntimeHost::new(
+    let host = std::sync::Arc::new(rtfs_compiler::runtime::host::RuntimeHost::new(
         Arc::new(std::sync::Mutex::new(rtfs_compiler::ccos::causal_chain::CausalChain::new().unwrap())),
         capability_marketplace,
         rtfs_compiler::runtime::security::RuntimeContext::pure(),

--- a/rtfs_compiler/src/bin/rtfs_compiler.rs
+++ b/rtfs_compiler/src/bin/rtfs_compiler.rs
@@ -285,7 +285,7 @@ fn main() {
                 let registry = std::sync::Arc::new(tokio::sync::RwLock::new(rtfs_compiler::runtime::capability_registry::CapabilityRegistry::new()));
                 let causal_chain = Arc::new(std::sync::Mutex::new(rtfs_compiler::ccos::causal_chain::CausalChain::new().unwrap()));
                 let capability_marketplace = Arc::new(rtfs_compiler::runtime::capability_marketplace::CapabilityMarketplace::new(registry));
-                let host = std::rc::Rc::new(RuntimeHost::new(
+                let host = std::sync::Arc::new(RuntimeHost::new(
                     causal_chain,
                     capability_marketplace,
                     rtfs_compiler::runtime::security::RuntimeContext::full(),

--- a/rtfs_compiler/src/bin/rtfs_compiler.rs
+++ b/rtfs_compiler/src/bin/rtfs_compiler.rs
@@ -122,7 +122,7 @@ impl From<RuntimeType> for Box<dyn RuntimeStrategy> {
                 let capability_marketplace = std::sync::Arc::new(rtfs_compiler::runtime::capability_marketplace::CapabilityMarketplace::new(registry.clone()));
                 
                 let causal_chain = Arc::new(std::sync::Mutex::new(rtfs_compiler::ccos::causal_chain::CausalChain::new().unwrap()));
-                let host = std::rc::Rc::new(RuntimeHost::new(
+                let host = std::sync::Arc::new(RuntimeHost::new(
                     causal_chain,
                     capability_marketplace,
                     rtfs_compiler::runtime::security::RuntimeContext::full(),

--- a/rtfs_compiler/src/ccos/orchestrator.rs
+++ b/rtfs_compiler/src/ccos/orchestrator.rs
@@ -75,7 +75,7 @@ impl Orchestrator {
         )?;
 
         // --- 2. Set up the Host and Evaluator ---
-        let host = Rc::new(RuntimeHost::new(
+        let host = Arc::new(RuntimeHost::new(
             self.causal_chain.clone(),
             self.capability_marketplace.clone(),
             context.clone(),
@@ -83,7 +83,7 @@ impl Orchestrator {
         host.set_execution_context(plan_id.clone(), plan.intent_ids.clone(), plan_action_id.clone());
         let module_registry = Rc::new(ModuleRegistry::new());
         let delegation_engine: Arc<dyn DelegationEngine> = Arc::new(StaticDelegationEngine::new(HashMap::new()));
-        let host_iface: Rc<dyn HostInterface> = host.clone();
+        let host_iface: Arc<dyn HostInterface> = host.clone();
         let mut evaluator = Evaluator::new(module_registry, delegation_engine, context.clone(), host_iface);
         
         // Initialize context manager for the plan execution

--- a/rtfs_compiler/src/development_tooling.rs
+++ b/rtfs_compiler/src/development_tooling.rs
@@ -533,7 +533,7 @@ impl RtfsTestFramework {
         let causal_chain = Arc::new(Mutex::new(CausalChain::new().expect("Failed to create causal chain")));
         let security_context = crate::runtime::security::RuntimeContext::pure();
         
-        let host = Rc::new(RuntimeHost::new(
+        let host = std::sync::Arc::new(RuntimeHost::new(
             causal_chain,
             capability_marketplace,
             security_context.clone(),

--- a/rtfs_compiler/src/development_tooling.rs
+++ b/rtfs_compiler/src/development_tooling.rs
@@ -92,7 +92,7 @@ impl RtfsRepl {
         let causal_chain = Arc::new(Mutex::new(CausalChain::new().expect("Failed to create causal chain")));
         let security_context = crate::runtime::security::RuntimeContext::pure();
         
-        let host = Rc::new(RuntimeHost::new(
+        let host = std::sync::Arc::new(RuntimeHost::new(
             causal_chain,
             capability_marketplace,
             security_context.clone(),
@@ -123,7 +123,7 @@ impl RtfsRepl {
                 let causal_chain = Arc::new(Mutex::new(CausalChain::new().expect("Failed to create causal chain")));
                 let security_context = crate::runtime::security::RuntimeContext::pure();
                 
-                let host = Rc::new(RuntimeHost::new(
+                let host = std::sync::Arc::new(RuntimeHost::new(
                     causal_chain,
                     capability_marketplace,
                     security_context.clone(),
@@ -247,7 +247,7 @@ impl RtfsRepl {
                 let causal_chain = Arc::new(Mutex::new(CausalChain::new().expect("Failed to create causal chain")));
                 let security_context = crate::runtime::security::RuntimeContext::pure();
                 
-                let host = Rc::new(RuntimeHost::new(
+                let host = std::sync::Arc::new(RuntimeHost::new(
                     causal_chain,
                     capability_marketplace,
                     security_context.clone(),

--- a/rtfs_compiler/src/runtime/ccos_environment.rs
+++ b/rtfs_compiler/src/runtime/ccos_environment.rs
@@ -96,7 +96,7 @@ impl Default for CCOSConfig {
 /// CCOS execution environment that manages the complete runtime
 pub struct CCOSEnvironment {
     config: CCOSConfig,
-    host: Rc<RuntimeHost>,
+    host: Arc<RuntimeHost>,
     evaluator: Evaluator,
     #[allow(dead_code)]
     marketplace: Arc<CapabilityMarketplace>,
@@ -120,7 +120,7 @@ impl CCOSEnvironment {
             SecurityLevel::Paranoid => RuntimeContext::pure(),
         };
         // Create runtime host
-        let host = Rc::new(RuntimeHost::new(
+        let host = Arc::new(RuntimeHost::new(
             causal_chain,
             marketplace.clone(),
             runtime_context.clone(),

--- a/rtfs_compiler/src/runtime/evaluator.rs
+++ b/rtfs_compiler/src/runtime/evaluator.rs
@@ -152,7 +152,7 @@ impl Evaluator {
         module_registry: Rc<ModuleRegistry>,
         delegation_engine: Arc<dyn DelegationEngine>,
         security_context: RuntimeContext,
-        host: Rc<dyn HostInterface>,
+        host: Arc<dyn HostInterface>,
     ) -> Self {
         let mut evaluator = Self::new(module_registry, delegation_engine, security_context, host);
         evaluator.type_config = TypeCheckingConfig {
@@ -2308,7 +2308,7 @@ impl Evaluator {
         env: Environment,
         delegation_engine: Arc<dyn DelegationEngine>,
         security_context: RuntimeContext,
-        host: Rc<dyn HostInterface>,
+        host: Arc<dyn HostInterface>,
     ) -> Self {
         Self {
             module_registry,
@@ -2351,7 +2351,7 @@ impl Default for Evaluator {
             capability_marketplace,
             security_context.clone(),
         );
-        let host = Rc::new(runtime_host);
+        let host = Arc::new(runtime_host);
 
         Self::new(
             module_registry,

--- a/rtfs_compiler/src/runtime/evaluator.rs
+++ b/rtfs_compiler/src/runtime/evaluator.rs
@@ -34,7 +34,7 @@ pub struct Evaluator {
     /// Security context for capability execution
     pub security_context: RuntimeContext,
     /// Host interface for CCOS interactions
-    pub host: Rc<dyn HostInterface>,
+    pub host: Arc<dyn HostInterface>,
     /// Dispatch table for special forms
     special_forms: HashMap<String, SpecialFormHandler>,
     /// Type validator for hybrid validation
@@ -80,7 +80,7 @@ impl Evaluator {
         module_registry: Rc<ModuleRegistry>, 
         delegation_engine: Arc<dyn DelegationEngine>,
         security_context: RuntimeContext,
-        host: Rc<dyn HostInterface>,
+        host: Arc<dyn HostInterface>,
     ) -> Self {
         let env = crate::runtime::stdlib::StandardLibrary::create_global_environment();
         let model_registry = Arc::new(ModelRegistry::with_defaults());
@@ -93,7 +93,7 @@ impl Evaluator {
             delegation_engine,
             model_registry,
             security_context,
-            host,
+        host,
             special_forms: Self::default_special_forms(),
             type_validator: Arc::new(TypeValidator::new()),
             type_config: TypeCheckingConfig::default(),
@@ -108,13 +108,13 @@ impl Evaluator {
     pub fn new_with_defaults(
         module_registry: Rc<ModuleRegistry>, 
         delegation_engine: Arc<dyn DelegationEngine>,
-        host: Rc<dyn HostInterface>,
+        host: Arc<dyn HostInterface>,
     ) -> Self {
         Self::new(
             module_registry,
             delegation_engine,
             RuntimeContext::pure(),
-            host,
+        host,
         )
     }
 
@@ -135,7 +135,7 @@ impl Evaluator {
         module_registry: Rc<ModuleRegistry>,
         delegation_engine: Arc<dyn DelegationEngine>,
         security_context: RuntimeContext,
-        host: Rc<dyn HostInterface>,
+        host: Arc<dyn HostInterface>,
     ) -> Self {
         let mut evaluator = Self::new(module_registry, delegation_engine, security_context, host);
         evaluator.type_config = TypeCheckingConfig {

--- a/rtfs_compiler/src/runtime/mod.rs
+++ b/rtfs_compiler/src/runtime/mod.rs
@@ -165,7 +165,7 @@ impl Runtime {
         let capability_marketplace = Arc::new(CapabilityMarketplace::new(capability_registry.clone()));
         let causal_chain = Arc::new(Mutex::new(CausalChain::new().expect("Failed to create causal chain")));
 
-        let host = Rc::new(RuntimeHost::new(
+        let host = std::sync::Arc::new(RuntimeHost::new(
             causal_chain,
             capability_marketplace,
             security_context.clone(),
@@ -186,7 +186,7 @@ impl Runtime {
         let capability_marketplace = Arc::new(CapabilityMarketplace::new(capability_registry.clone()));
         let causal_chain = Arc::new(Mutex::new(CausalChain::new().expect("Failed to create causal chain")));
 
-        let host = Rc::new(RuntimeHost::new(
+        let host = std::sync::Arc::new(RuntimeHost::new(
             causal_chain,
             capability_marketplace,
             security_context.clone(),
@@ -207,7 +207,7 @@ impl Runtime {
         let capability_marketplace = Arc::new(CapabilityMarketplace::new(capability_registry.clone()));       
         let causal_chain = Arc::new(Mutex::new(CausalChain::new().expect("Failed to create causal chain")));
 
-        let host = Rc::new(RuntimeHost::new(
+        let host = std::sync::Arc::new(RuntimeHost::new(
             causal_chain,
             capability_marketplace,
             security_context.clone(),
@@ -256,7 +256,7 @@ impl IrWithFallbackStrategy {
         let capability_marketplace = Arc::new(CapabilityMarketplace::new(capability_registry.clone()));
         let causal_chain = Arc::new(Mutex::new(CausalChain::new().expect("Failed to create causal chain")));
 
-        let host = Rc::new(RuntimeHost::new(
+        let host = std::sync::Arc::new(RuntimeHost::new(
             causal_chain,
             capability_marketplace,
             security_context.clone(),

--- a/rtfs_compiler/src/tests/collections_tests.rs
+++ b/rtfs_compiler/src/tests/collections_tests.rs
@@ -63,7 +63,7 @@ mod collections_tests {
         let capability_marketplace = std::sync::Arc::new(crate::runtime::capability_marketplace::CapabilityMarketplace::new(registry));
         let causal_chain = std::sync::Arc::new(std::sync::Mutex::new(crate::ccos::causal_chain::CausalChain::new().unwrap()));
         let security_context = crate::runtime::security::RuntimeContext::pure();
-        let host = std::rc::Rc::new(crate::runtime::host::RuntimeHost::new(
+        let host = std::sync::Arc::new(crate::runtime::host::RuntimeHost::new(
             causal_chain,
             capability_marketplace,
             security_context.clone(),

--- a/rtfs_compiler/src/tests/control_flow_tests.rs
+++ b/rtfs_compiler/src/tests/control_flow_tests.rs
@@ -51,7 +51,7 @@ mod control_flow_tests {
         let capability_marketplace = std::sync::Arc::new(crate::runtime::capability_marketplace::CapabilityMarketplace::new(registry));
         let causal_chain = std::sync::Arc::new(std::sync::Mutex::new(crate::ccos::causal_chain::CausalChain::new().unwrap()));
         let security_context = crate::runtime::security::RuntimeContext::pure();
-        let host = std::rc::Rc::new(crate::runtime::host::RuntimeHost::new(
+        let host = std::sync::Arc::new(crate::runtime::host::RuntimeHost::new(
             causal_chain,
             capability_marketplace,
             security_context.clone(),

--- a/rtfs_compiler/src/tests/function_tests.rs
+++ b/rtfs_compiler/src/tests/function_tests.rs
@@ -167,7 +167,7 @@ mod function_tests {
         let capability_marketplace = std::sync::Arc::new(crate::runtime::capability_marketplace::CapabilityMarketplace::new(registry));
         let causal_chain = std::sync::Arc::new(std::sync::Mutex::new(crate::ccos::causal_chain::CausalChain::new().unwrap()));
         let security_context =  crate::runtime::security::RuntimeContext::pure();
-        let host = std::rc::Rc::new(crate::runtime::host::RuntimeHost::new(
+        let host = std::sync::Arc::new(crate::runtime::host::RuntimeHost::new(
             causal_chain,
             capability_marketplace,
             security_context.clone(),
@@ -197,7 +197,7 @@ mod function_tests {
         let capability_marketplace = std::sync::Arc::new(crate::runtime::capability_marketplace::CapabilityMarketplace::new(registry));
         let causal_chain = std::sync::Arc::new(std::sync::Mutex::new(crate::ccos::causal_chain::CausalChain::new().unwrap()));
         let security_context = crate::runtime::security::RuntimeContext::pure();
-        let host = std::rc::Rc::new(crate::runtime::host::RuntimeHost::new(
+        let host = std::sync::Arc::new(crate::runtime::host::RuntimeHost::new(
             causal_chain,
             capability_marketplace,
             security_context.clone(),

--- a/rtfs_compiler/src/tests/object_tests.rs
+++ b/rtfs_compiler/src/tests/object_tests.rs
@@ -129,7 +129,7 @@ mod object_tests {
         let capability_marketplace = std::sync::Arc::new(crate::runtime::capability_marketplace::CapabilityMarketplace::new(registry));
         let causal_chain = std::sync::Arc::new(std::sync::Mutex::new(crate::ccos::causal_chain::CausalChain::new().unwrap()));
         let security_context =  crate::runtime::security::RuntimeContext::pure();
-        let host = std::rc::Rc::new(crate::runtime::host::RuntimeHost::new(
+        let host = std::sync::Arc::new(crate::runtime::host::RuntimeHost::new(
             causal_chain,
             capability_marketplace,
             security_context.clone(),
@@ -151,7 +151,7 @@ mod object_tests {
         let capability_marketplace = std::sync::Arc::new(crate::runtime::capability_marketplace::CapabilityMarketplace::new(registry));
         let causal_chain = std::sync::Arc::new(std::sync::Mutex::new(crate::ccos::causal_chain::CausalChain::new().unwrap()));
         let security_context =  crate::runtime::security::RuntimeContext::pure();
-        let host = std::rc::Rc::new(crate::runtime::host::RuntimeHost::new(
+        let host = std::sync::Arc::new(crate::runtime::host::RuntimeHost::new(
             causal_chain,
             capability_marketplace,
             security_context.clone(),

--- a/rtfs_compiler/src/tests/primitives_tests.rs
+++ b/rtfs_compiler/src/tests/primitives_tests.rs
@@ -69,7 +69,7 @@ mod primitives_tests {
         let capability_marketplace = std::sync::Arc::new(crate::runtime::capability_marketplace::CapabilityMarketplace::new(registry));
         let causal_chain = std::sync::Arc::new(std::sync::Mutex::new(crate::ccos::causal_chain::CausalChain::new().unwrap()));
         let security_context =  crate::runtime::security::RuntimeContext::pure();
-        let host = std::rc::Rc::new(crate::runtime::host::RuntimeHost::new(
+        let host = std::sync::Arc::new(crate::runtime::host::RuntimeHost::new(
             causal_chain,
             capability_marketplace,
             security_context.clone(),

--- a/rtfs_compiler/src/tests/test_helpers.rs
+++ b/rtfs_compiler/src/tests/test_helpers.rs
@@ -51,11 +51,11 @@ pub fn create_module_registry() -> Rc<ModuleRegistry> {
 }
 
 /// Creates a runtime host with the specified security context
-pub fn create_runtime_host(security_context: RuntimeContext) -> Rc<RuntimeHost> {
+pub fn create_runtime_host(security_context: RuntimeContext) -> std::sync::Arc<RuntimeHost> {
     let registry = create_capability_registry();
     let capability_marketplace = Arc::new(CapabilityMarketplace::new(registry));
     let causal_chain = std::sync::Arc::new(std::sync::Mutex::new(CausalChain::new().unwrap()));
-    Rc::new(RuntimeHost::new(
+    std::sync::Arc::new(RuntimeHost::new(
         causal_chain,
         capability_marketplace,
         security_context.clone(),
@@ -66,10 +66,10 @@ pub fn create_runtime_host(security_context: RuntimeContext) -> Rc<RuntimeHost> 
 pub fn create_runtime_host_with_marketplace(
     marketplace: Arc<CapabilityMarketplace>,
     security_context: RuntimeContext,
-) -> Rc<RuntimeHost> {
+) -> std::sync::Arc<RuntimeHost> {
     let causal_chain = std::sync::Arc::new(std::sync::Mutex::new(CausalChain::new().unwrap()));
     
-    Rc::new(RuntimeHost::new(
+    std::sync::Arc::new(RuntimeHost::new(
         causal_chain,
         marketplace,
         security_context.clone(),

--- a/rtfs_compiler/src/tests/test_utils.rs
+++ b/rtfs_compiler/src/tests/test_utils.rs
@@ -28,7 +28,7 @@ pub fn create_test_evaluator() -> Evaluator {
     let capability_marketplace = std::sync::Arc::new(crate::runtime::capability_marketplace::CapabilityMarketplace::new(registry));
     let causal_chain = std::sync::Arc::new(std::sync::Mutex::new(crate::ccos::causal_chain::CausalChain::new().unwrap()));
     let security_context = crate::runtime::security::RuntimeContext::pure();
-    let host = std::rc::Rc::new(crate::runtime::host::RuntimeHost::new(
+    let host = std::sync::Arc::new(crate::runtime::host::RuntimeHost::new(
         causal_chain,
         capability_marketplace,
         security_context.clone(),
@@ -49,7 +49,7 @@ pub fn create_test_evaluator_with_context(ctx: crate::runtime::security::Runtime
     let registry = std::sync::Arc::new(tokio::sync::RwLock::new(crate::runtime::capability_registry::CapabilityRegistry::new()));
     let capability_marketplace = std::sync::Arc::new(crate::runtime::capability_marketplace::CapabilityMarketplace::new(registry));
     let causal_chain = std::sync::Arc::new(std::sync::Mutex::new(crate::ccos::causal_chain::CausalChain::new().unwrap()));
-    let host = std::rc::Rc::new(crate::runtime::host::RuntimeHost::new(
+    let host = std::sync::Arc::new(crate::runtime::host::RuntimeHost::new(
         causal_chain,
         capability_marketplace,
         ctx.clone(),

--- a/rtfs_compiler/tests/basic_validation.rs
+++ b/rtfs_compiler/tests/basic_validation.rs
@@ -21,7 +21,7 @@ fn parse_and_evaluate(input: &str) -> RuntimeResult<Value> {
     let capability_marketplace = std::sync::Arc::new(rtfs_compiler::runtime::capability_marketplace::CapabilityMarketplace::new(registry));
     let causal_chain = std::sync::Arc::new(std::sync::Mutex::new(rtfs_compiler::ccos::causal_chain::CausalChain::new().unwrap()));
     let security_context = rtfs_compiler::runtime::security::RuntimeContext::pure();
-    let host = std::rc::Rc::new(rtfs_compiler::runtime::host::RuntimeHost::new(
+    let host = std::sync::Arc::new(rtfs_compiler::runtime::host::RuntimeHost::new(
         causal_chain,
         capability_marketplace,
         security_context.clone(),

--- a/rtfs_compiler/tests/execution_context_tests.rs
+++ b/rtfs_compiler/tests/execution_context_tests.rs
@@ -210,7 +210,7 @@ fn test_merge_policy_keyword_overwrite_in_step_parallel() -> RuntimeResult<()> {
         use tokio::sync::RwLock;
         Arc::new(CapabilityMarketplace::new(Arc::new(RwLock::new(CapabilityRegistry::new()))))
     };
-    let host = Rc::new(RuntimeHost::new(causal_chain, capability_marketplace, RuntimeContext::pure()));
+    let host = std::sync::Arc::new(RuntimeHost::new(causal_chain, capability_marketplace, RuntimeContext::pure()));
     let evaluator = Evaluator::new(module_registry, Arc::new(rtfs_compiler::ccos::delegation::StaticDelegationEngine::new(std::collections::HashMap::new())), RuntimeContext::pure(), host);
 
     // Initialize root context and set parent value :k = "parent"

--- a/rtfs_compiler/tests/http_capability_tests/test_helpers.rs
+++ b/rtfs_compiler/tests/http_capability_tests/test_helpers.rs
@@ -51,11 +51,11 @@ pub fn create_module_registry() -> Rc<ModuleRegistry> {
 }
 
 /// Creates a runtime host with the specified security context
-pub fn create_runtime_host(security_context: RuntimeContext) -> Rc<RuntimeHost> {
+pub fn create_runtime_host(security_context: RuntimeContext) -> std::sync::Arc<RuntimeHost> {
     let marketplace = Arc::new(create_capability_marketplace());
     let causal_chain = create_causal_chain();
     
-    Rc::new(RuntimeHost::new(
+    std::sync::Arc::new(RuntimeHost::new(
         marketplace,
         causal_chain,
         security_context,
@@ -66,10 +66,10 @@ pub fn create_runtime_host(security_context: RuntimeContext) -> Rc<RuntimeHost> 
 pub fn create_runtime_host_with_marketplace(
     marketplace: Arc<CapabilityMarketplace>,
     security_context: RuntimeContext,
-) -> Rc<RuntimeHost> {
+) -> std::sync::Arc<RuntimeHost> {
     let causal_chain = create_causal_chain();
     
-    Rc::new(RuntimeHost::new(
+    std::sync::Arc::new(RuntimeHost::new(
         marketplace,
         causal_chain,
         security_context,

--- a/rtfs_compiler/tests/l4_cache_integration.rs
+++ b/rtfs_compiler/tests/l4_cache_integration.rs
@@ -45,7 +45,7 @@ fn test_l4_cache_wasm_execution() -> RuntimeResult<()> {
     let capability_marketplace = std::sync::Arc::new(rtfs_compiler::runtime::capability_marketplace::CapabilityMarketplace::new(registry));
     let causal_chain = std::sync::Arc::new(std::sync::Mutex::new(rtfs_compiler::ccos::causal_chain::CausalChain::new().unwrap()));
     let security_context = rtfs_compiler::runtime::security::RuntimeContext::pure();
-    let host = std::rc::Rc::new(rtfs_compiler::runtime::host::RuntimeHost::new(
+    let host = std::sync::Arc::new(rtfs_compiler::runtime::host::RuntimeHost::new(
         causal_chain,
         capability_marketplace,
         security_context.clone(),
@@ -91,7 +91,7 @@ fn test_l4_cache_with_local_definition() -> RuntimeResult<()> {
     let capability_marketplace = std::sync::Arc::new(rtfs_compiler::runtime::capability_marketplace::CapabilityMarketplace::new(registry));
     let causal_chain = std::sync::Arc::new(std::sync::Mutex::new(rtfs_compiler::ccos::causal_chain::CausalChain::new().unwrap()));
     let security_context = rtfs_compiler::runtime::security::RuntimeContext::pure();
-    let host = std::rc::Rc::new(rtfs_compiler::runtime::host::RuntimeHost::new(
+    let host = std::sync::Arc::new(rtfs_compiler::runtime::host::RuntimeHost::new(
         causal_chain,
         capability_marketplace,
         security_context.clone(),

--- a/rtfs_compiler/tests/orchestrator_checkpoint_tests.rs
+++ b/rtfs_compiler/tests/orchestrator_checkpoint_tests.rs
@@ -18,7 +18,7 @@ fn test_checkpoint_and_resume_helpers() {
     // Minimal plan and evaluator
     let plan = Plan::new_rtfs("(+ 1 1)".to_string(), vec!["intent-1".to_string()]);
     let runtime_context = RuntimeContext::pure();
-    let host = std::rc::Rc::new(rtfs_compiler::runtime::host::RuntimeHost::new(
+    let host = std::sync::Arc::new(rtfs_compiler::runtime::host::RuntimeHost::new(
         causal_chain.clone(),
         Arc::new(rtfs_compiler::runtime::capability_marketplace::CapabilityMarketplace::new(
             Arc::new(tokio::sync::RwLock::new(rtfs_compiler::runtime::capability_registry::CapabilityRegistry::new()))

--- a/rtfs_compiler/tests/readme_scenario_test.rs
+++ b/rtfs_compiler/tests/readme_scenario_test.rs
@@ -42,7 +42,7 @@ async fn test_readme_scenario() {
         capability_marketplace,
         security_context.clone(),
     );
-    let host = Rc::new(runtime_host);
+    let host = std::sync::Arc::new(runtime_host);
     
     // Create evaluator
     let evaluator = Evaluator::new(

--- a/rtfs_compiler/tests/runtime_type_integration_tests.rs
+++ b/rtfs_compiler/tests/runtime_type_integration_tests.rs
@@ -62,7 +62,7 @@ mod hybrid_runtime_integration_tests {
         let static_map = HashMap::new();
         let delegation_engine = Arc::new(StaticDelegationEngine::new(static_map));
         let security_context = RuntimeContext::pure();
-        let host = Rc::new(MockHost);
+        let host = Arc::new(MockHost);
         
         Evaluator::new_optimized(module_registry, delegation_engine, security_context, host)
     }
@@ -72,7 +72,7 @@ mod hybrid_runtime_integration_tests {
         let static_map = HashMap::new();
         let delegation_engine = Arc::new(StaticDelegationEngine::new(static_map));
         let security_context = RuntimeContext::pure();
-        let host = Rc::new(MockHost);
+        let host = Arc::new(MockHost);
         
         Evaluator::new_strict(module_registry, delegation_engine, security_context, host)
     }

--- a/rtfs_compiler/tests/secure_stdlib_comprehensive_tests.rs
+++ b/rtfs_compiler/tests/secure_stdlib_comprehensive_tests.rs
@@ -27,7 +27,7 @@ impl SecureStdlibTestRunner {
             rtfs_compiler::ccos::causal_chain::CausalChain::new().unwrap()
         ));
         let security_context = rtfs_compiler::runtime::security::RuntimeContext::pure();
-        let host = Rc::new(rtfs_compiler::runtime::host::RuntimeHost::new(
+        let host = std::sync::Arc::new(rtfs_compiler::runtime::host::RuntimeHost::new(
             causal_chain,
             capability_marketplace,
             security_context.clone(),

--- a/rtfs_compiler/tests/stdlib_e2e_tests.rs
+++ b/rtfs_compiler/tests/stdlib_e2e_tests.rs
@@ -26,7 +26,7 @@ impl StdlibTestRunner {
             rtfs_compiler::ccos::causal_chain::CausalChain::new().unwrap()
         ));
         let security_context = rtfs_compiler::runtime::security::RuntimeContext::pure();
-        let host = Rc::new(rtfs_compiler::runtime::host::RuntimeHost::new(
+        let host = std::sync::Arc::new(rtfs_compiler::runtime::host::RuntimeHost::new(
             causal_chain,
             capability_marketplace,
             security_context.clone(),

--- a/rtfs_compiler/tests/test_execution_context_fix.rs
+++ b/rtfs_compiler/tests/test_execution_context_fix.rs
@@ -67,7 +67,7 @@ fn test_execution_context_validation() {
     let registry = Arc::new(RwLock::new(CapabilityRegistry::new()));
     let marketplace = Arc::new(CapabilityMarketplace::new(registry));
     
-    let host = Rc::new(RuntimeHost::new(
+    let host = std::sync::Arc::new(RuntimeHost::new(
         causal_chain,
         marketplace,
         security_context.clone(),
@@ -80,7 +80,7 @@ fn test_execution_context_validation() {
         stdlib_env,
         delegation_engine,
         security_context,
-        host.clone() as Rc<dyn HostInterface>,
+        host.clone() as std::sync::Arc<dyn HostInterface>,
     );
     
     // Test simple RTFS code that doesn't require capability execution

--- a/rtfs_compiler/tests/test_helpers.rs
+++ b/rtfs_compiler/tests/test_helpers.rs
@@ -60,7 +60,7 @@ pub fn create_module_registry() -> Rc<ModuleRegistry> {
 }
 
 /// Creates a runtime host with the specified security context
-pub fn create_runtime_host(security_context: RuntimeContext) -> Rc<RuntimeHost> {
+pub fn create_runtime_host(security_context: RuntimeContext) -> std::sync::Arc<RuntimeHost> {
     let marketplace = Arc::new(create_capability_marketplace());
     let causal_chain = create_causal_chain();
     
@@ -68,7 +68,7 @@ pub fn create_runtime_host(security_context: RuntimeContext) -> Rc<RuntimeHost> 
     let capability_marketplace = std::sync::Arc::new(rtfs_compiler::runtime::capability_marketplace::CapabilityMarketplace::new(registry));
     let causal_chain = std::sync::Arc::new(std::sync::Mutex::new(rtfs_compiler::ccos::causal_chain::CausalChain::new().unwrap()));
     let security_context = rtfs_compiler::runtime::security::RuntimeContext::pure();
-    let host = std::rc::Rc::new(rtfs_compiler::runtime::host::RuntimeHost::new(
+    let host = std::sync::Arc::new(rtfs_compiler::runtime::host::RuntimeHost::new(
         causal_chain,
         capability_marketplace,
         security_context.clone(),
@@ -80,10 +80,10 @@ pub fn create_runtime_host(security_context: RuntimeContext) -> Rc<RuntimeHost> 
 pub fn create_runtime_host_with_marketplace(
     capability_marketplace: Arc<CapabilityMarketplace>,
     security_context: RuntimeContext,
-) -> Rc<RuntimeHost> {
+) -> std::sync::Arc<RuntimeHost> {
     
     let causal_chain = std::sync::Arc::new(std::sync::Mutex::new(rtfs_compiler::ccos::causal_chain::CausalChain::new().unwrap()));
-    let host = std::rc::Rc::new(rtfs_compiler::runtime::host::RuntimeHost::new(
+    let host = std::sync::Arc::new(rtfs_compiler::runtime::host::RuntimeHost::new(
         causal_chain,
         capability_marketplace,
         security_context.clone(),

--- a/rtfs_compiler/tests/test_implemented_functions.rs
+++ b/rtfs_compiler/tests/test_implemented_functions.rs
@@ -15,7 +15,7 @@ fn test_factorial() {
     let capability_marketplace = std::sync::Arc::new(rtfs_compiler::runtime::capability_marketplace::CapabilityMarketplace::new(registry));
     let causal_chain = std::sync::Arc::new(std::sync::Mutex::new(rtfs_compiler::ccos::causal_chain::CausalChain::new().unwrap()));
     let security_context = rtfs_compiler::runtime::security::RuntimeContext::pure();
-    let host = std::rc::Rc::new(rtfs_compiler::runtime::host::RuntimeHost::new(
+    let host = std::sync::Arc::new(rtfs_compiler::runtime::host::RuntimeHost::new(
         causal_chain,
         capability_marketplace,
         security_context.clone(),
@@ -61,7 +61,7 @@ fn test_length_value() {
     let capability_marketplace = std::sync::Arc::new(rtfs_compiler::runtime::capability_marketplace::CapabilityMarketplace::new(registry));
     let causal_chain = std::sync::Arc::new(std::sync::Mutex::new(rtfs_compiler::ccos::causal_chain::CausalChain::new().unwrap()));
     let security_context = rtfs_compiler::runtime::security::RuntimeContext::pure();
-    let host = std::rc::Rc::new(rtfs_compiler::runtime::host::RuntimeHost::new(
+    let host = std::sync::Arc::new(rtfs_compiler::runtime::host::RuntimeHost::new(
         causal_chain,
         capability_marketplace,
         security_context.clone(),
@@ -113,7 +113,7 @@ fn test_current_time() {
     let capability_marketplace = std::sync::Arc::new(rtfs_compiler::runtime::capability_marketplace::CapabilityMarketplace::new(registry));
     let causal_chain = std::sync::Arc::new(std::sync::Mutex::new(rtfs_compiler::ccos::causal_chain::CausalChain::new().unwrap()));
     let security_context = rtfs_compiler::runtime::security::RuntimeContext::pure();
-    let host = std::rc::Rc::new(rtfs_compiler::runtime::host::RuntimeHost::new(
+    let host = std::sync::Arc::new(rtfs_compiler::runtime::host::RuntimeHost::new(
         causal_chain,
         capability_marketplace,
         security_context.clone(),
@@ -146,7 +146,7 @@ fn test_json_functions() {
     let capability_marketplace = std::sync::Arc::new(rtfs_compiler::runtime::capability_marketplace::CapabilityMarketplace::new(registry));
     let causal_chain = std::sync::Arc::new(std::sync::Mutex::new(rtfs_compiler::ccos::causal_chain::CausalChain::new().unwrap()));
     let security_context = rtfs_compiler::runtime::security::RuntimeContext::pure();
-    let host = std::rc::Rc::new(rtfs_compiler::runtime::host::RuntimeHost::new(
+    let host = std::sync::Arc::new(rtfs_compiler::runtime::host::RuntimeHost::new(
         causal_chain,
         capability_marketplace,
         security_context.clone(),
@@ -226,7 +226,7 @@ fn test_file_exists() {
     let capability_marketplace = std::sync::Arc::new(rtfs_compiler::runtime::capability_marketplace::CapabilityMarketplace::new(registry));
     let causal_chain = std::sync::Arc::new(std::sync::Mutex::new(rtfs_compiler::ccos::causal_chain::CausalChain::new().unwrap()));
     let security_context = rtfs_compiler::runtime::security::RuntimeContext::pure();
-    let host = std::rc::Rc::new(rtfs_compiler::runtime::host::RuntimeHost::new(
+    let host = std::sync::Arc::new(rtfs_compiler::runtime::host::RuntimeHost::new(
         causal_chain,
         capability_marketplace,
         security_context.clone(),
@@ -257,7 +257,7 @@ fn test_get_env() {
     let capability_marketplace = std::sync::Arc::new(rtfs_compiler::runtime::capability_marketplace::CapabilityMarketplace::new(registry));
     let causal_chain = std::sync::Arc::new(std::sync::Mutex::new(rtfs_compiler::ccos::causal_chain::CausalChain::new().unwrap()));
     let security_context = rtfs_compiler::runtime::security::RuntimeContext::pure();
-    let host = std::rc::Rc::new(rtfs_compiler::runtime::host::RuntimeHost::new(
+    let host = std::sync::Arc::new(rtfs_compiler::runtime::host::RuntimeHost::new(
         causal_chain,
         capability_marketplace,
         security_context.clone(),
@@ -294,7 +294,7 @@ fn test_log_function() {
     let capability_marketplace = std::sync::Arc::new(rtfs_compiler::runtime::capability_marketplace::CapabilityMarketplace::new(registry));
     let causal_chain = std::sync::Arc::new(std::sync::Mutex::new(rtfs_compiler::ccos::causal_chain::CausalChain::new().unwrap()));
     let security_context = rtfs_compiler::runtime::security::RuntimeContext::pure();
-    let host = std::rc::Rc::new(rtfs_compiler::runtime::host::RuntimeHost::new(
+    let host = std::sync::Arc::new(rtfs_compiler::runtime::host::RuntimeHost::new(
         causal_chain,
         capability_marketplace,
         security_context.clone(),
@@ -326,7 +326,7 @@ fn test_agent_functions() {
     let capability_marketplace = std::sync::Arc::new(rtfs_compiler::runtime::capability_marketplace::CapabilityMarketplace::new(registry));
     let causal_chain = std::sync::Arc::new(std::sync::Mutex::new(rtfs_compiler::ccos::causal_chain::CausalChain::new().unwrap()));
     let security_context = rtfs_compiler::runtime::security::RuntimeContext::pure();
-    let host = std::rc::Rc::new(rtfs_compiler::runtime::host::RuntimeHost::new(
+    let host = std::sync::Arc::new(rtfs_compiler::runtime::host::RuntimeHost::new(
         causal_chain,
         capability_marketplace,
         security_context.clone(),
@@ -384,7 +384,7 @@ fn test_map_filter_functions() {
     let capability_marketplace = std::sync::Arc::new(rtfs_compiler::runtime::capability_marketplace::CapabilityMarketplace::new(registry));
     let causal_chain = std::sync::Arc::new(std::sync::Mutex::new(rtfs_compiler::ccos::causal_chain::CausalChain::new().unwrap()));
     let security_context = rtfs_compiler::runtime::security::RuntimeContext::pure();
-    let host = std::rc::Rc::new(rtfs_compiler::runtime::host::RuntimeHost::new(
+    let host = std::sync::Arc::new(rtfs_compiler::runtime::host::RuntimeHost::new(
         causal_chain,
         capability_marketplace,
         security_context.clone(),
@@ -435,7 +435,7 @@ fn test_reduce_function() {
     let capability_marketplace = std::sync::Arc::new(rtfs_compiler::runtime::capability_marketplace::CapabilityMarketplace::new(registry));
     let causal_chain = std::sync::Arc::new(std::sync::Mutex::new(rtfs_compiler::ccos::causal_chain::CausalChain::new().unwrap()));
     let security_context = rtfs_compiler::runtime::security::RuntimeContext::pure();
-    let host = std::rc::Rc::new(rtfs_compiler::runtime::host::RuntimeHost::new(
+    let host = std::sync::Arc::new(rtfs_compiler::runtime::host::RuntimeHost::new(
         causal_chain,
         capability_marketplace,
         security_context.clone(),

--- a/rtfs_compiler/tests/test_missing_stdlib_functions.rs
+++ b/rtfs_compiler/tests/test_missing_stdlib_functions.rs
@@ -14,7 +14,7 @@ fn test_missing_stdlib_functions() {
     let capability_marketplace = std::sync::Arc::new(rtfs_compiler::runtime::capability_marketplace::CapabilityMarketplace::new(registry));
     let causal_chain = std::sync::Arc::new(std::sync::Mutex::new(rtfs_compiler::ccos::causal_chain::CausalChain::new().unwrap()));
     let security_context = rtfs_compiler::runtime::security::RuntimeContext::pure();
-    let host = std::rc::Rc::new(rtfs_compiler::runtime::host::RuntimeHost::new(
+    let host = std::sync::Arc::new(rtfs_compiler::runtime::host::RuntimeHost::new(
         causal_chain,
         capability_marketplace,
         security_context.clone(),

--- a/rtfs_compiler/tests/test_recursive_patterns.rs
+++ b/rtfs_compiler/tests/test_recursive_patterns.rs
@@ -19,7 +19,7 @@ fn test_mutual_recursion_pattern() {
     let capability_marketplace = std::sync::Arc::new(rtfs_compiler::runtime::capability_marketplace::CapabilityMarketplace::new(registry));
     let causal_chain = std::sync::Arc::new(std::sync::Mutex::new(rtfs_compiler::ccos::causal_chain::CausalChain::new().unwrap()));
     let security_context = rtfs_compiler::runtime::security::RuntimeContext::pure();
-    let host = std::rc::Rc::new(rtfs_compiler::runtime::host::RuntimeHost::new(
+    let host = std::sync::Arc::new(rtfs_compiler::runtime::host::RuntimeHost::new(
         causal_chain,
         capability_marketplace,
         security_context.clone(),
@@ -60,7 +60,7 @@ fn test_nested_recursion_pattern() {
     let capability_marketplace = std::sync::Arc::new(rtfs_compiler::runtime::capability_marketplace::CapabilityMarketplace::new(registry));
     let causal_chain = std::sync::Arc::new(std::sync::Mutex::new(rtfs_compiler::ccos::causal_chain::CausalChain::new().unwrap()));
     let security_context = rtfs_compiler::runtime::security::RuntimeContext::pure();
-    let host = std::rc::Rc::new(rtfs_compiler::runtime::host::RuntimeHost::new(
+    let host = std::sync::Arc::new(rtfs_compiler::runtime::host::RuntimeHost::new(
         causal_chain,
         capability_marketplace,
         security_context.clone(),
@@ -89,7 +89,7 @@ fn test_higher_order_recursion_pattern() {
     let capability_marketplace = std::sync::Arc::new(rtfs_compiler::runtime::capability_marketplace::CapabilityMarketplace::new(registry));
     let causal_chain = std::sync::Arc::new(std::sync::Mutex::new(rtfs_compiler::ccos::causal_chain::CausalChain::new().unwrap()));
     let security_context = rtfs_compiler::runtime::security::RuntimeContext::pure();
-    let host = std::rc::Rc::new(rtfs_compiler::runtime::host::RuntimeHost::new(
+    let host = std::sync::Arc::new(rtfs_compiler::runtime::host::RuntimeHost::new(
         causal_chain,
         capability_marketplace,
         security_context.clone(),
@@ -118,7 +118,7 @@ fn test_three_way_recursion_pattern() {
     let capability_marketplace = std::sync::Arc::new(rtfs_compiler::runtime::capability_marketplace::CapabilityMarketplace::new(registry));
     let causal_chain = std::sync::Arc::new(std::sync::Mutex::new(rtfs_compiler::ccos::causal_chain::CausalChain::new().unwrap()));
     let security_context = rtfs_compiler::runtime::security::RuntimeContext::pure();
-    let host = std::rc::Rc::new(rtfs_compiler::runtime::host::RuntimeHost::new(
+    let host = std::sync::Arc::new(rtfs_compiler::runtime::host::RuntimeHost::new(
         causal_chain,
         capability_marketplace,
         security_context.clone(),

--- a/rtfs_compiler/tests/test_simple_recursion.rs
+++ b/rtfs_compiler/tests/test_simple_recursion.rs
@@ -26,7 +26,7 @@ fn test_simple_mutual_recursion() {
     let capability_marketplace = std::sync::Arc::new(rtfs_compiler::runtime::capability_marketplace::CapabilityMarketplace::new(registry));
     let causal_chain = std::sync::Arc::new(std::sync::Mutex::new(rtfs_compiler::ccos::causal_chain::CausalChain::new().unwrap()));
     let security_context = rtfs_compiler::runtime::security::RuntimeContext::pure();
-    let host = std::rc::Rc::new(rtfs_compiler::runtime::host::RuntimeHost::new(
+    let host = std::sync::Arc::new(rtfs_compiler::runtime::host::RuntimeHost::new(
         causal_chain,
         capability_marketplace,
         security_context.clone(),
@@ -65,7 +65,7 @@ fn test_simple_factorial() {
     let capability_marketplace = std::sync::Arc::new(rtfs_compiler::runtime::capability_marketplace::CapabilityMarketplace::new(registry));
     let causal_chain = std::sync::Arc::new(std::sync::Mutex::new(rtfs_compiler::ccos::causal_chain::CausalChain::new().unwrap()));
     let security_context = rtfs_compiler::runtime::security::RuntimeContext::pure();
-    let host = std::rc::Rc::new(rtfs_compiler::runtime::host::RuntimeHost::new(
+    let host = std::sync::Arc::new(rtfs_compiler::runtime::host::RuntimeHost::new(
         causal_chain,
         capability_marketplace,
         security_context.clone(),

--- a/rtfs_compiler/tests/test_simple_recursion_new.rs
+++ b/rtfs_compiler/tests/test_simple_recursion_new.rs
@@ -23,7 +23,7 @@ fn test_simple_mutual_recursion() {
     let capability_marketplace = std::sync::Arc::new(rtfs_compiler::runtime::capability_marketplace::CapabilityMarketplace::new(registry));
     let causal_chain = std::sync::Arc::new(std::sync::Mutex::new(rtfs_compiler::ccos::causal_chain::CausalChain::new().unwrap()));
     let security_context = rtfs_compiler::runtime::security::RuntimeContext::pure();
-    let host = std::rc::Rc::new(rtfs_compiler::runtime::host::RuntimeHost::new(
+    let host = std::sync::Arc::new(rtfs_compiler::runtime::host::RuntimeHost::new(
         causal_chain,
         capability_marketplace,
         security_context.clone(),
@@ -57,7 +57,7 @@ fn test_simple_factorial() {
     let capability_marketplace = std::sync::Arc::new(rtfs_compiler::runtime::capability_marketplace::CapabilityMarketplace::new(registry));
     let causal_chain = std::sync::Arc::new(std::sync::Mutex::new(rtfs_compiler::ccos::causal_chain::CausalChain::new().unwrap()));
     let security_context = rtfs_compiler::runtime::security::RuntimeContext::pure();
-    let host = std::rc::Rc::new(rtfs_compiler::runtime::host::RuntimeHost::new(
+    let host = std::sync::Arc::new(rtfs_compiler::runtime::host::RuntimeHost::new(
         causal_chain,
         capability_marketplace,
         security_context.clone(),

--- a/rtfs_compiler/tests/test_type_annotation_whitespace.rs
+++ b/rtfs_compiler/tests/test_type_annotation_whitespace.rs
@@ -16,7 +16,7 @@ fn test_parse_and_execute(code: &str, test_name: &str) -> (bool, String) {
     let capability_marketplace = std::sync::Arc::new(rtfs_compiler::runtime::capability_marketplace::CapabilityMarketplace::new(registry));
     let causal_chain = std::sync::Arc::new(std::sync::Mutex::new(rtfs_compiler::ccos::causal_chain::CausalChain::new().unwrap()));
     let security_context = rtfs_compiler::runtime::security::RuntimeContext::pure();
-    let host = std::rc::Rc::new(rtfs_compiler::runtime::host::RuntimeHost::new(
+    let host = std::sync::Arc::new(rtfs_compiler::runtime::host::RuntimeHost::new(
         causal_chain,
         capability_marketplace,
         security_context.clone(),


### PR DESCRIPTION
### Issue
- Addresses [Issue #88](https://github.com/mandubian/ccos/issues/88): Thread-safe Host + foundation for true parallel `step-parallel` across AST/IR runtimes

### Summary
- Make `RuntimeHost` thread-safe and update `Evaluator` to accept `Arc<dyn HostInterface>`.
- No behavioral changes; enables safe parallelization work in a follow-up PR.

### Why
- Remove single-thread limitations in the host to support true parallel execution.
- Shared groundwork for both AST and IR runtimes.

### What changed
- Runtime host internals
  - `execution_context`: `RefCell<Option<...>>` → `Mutex<Option<...>>`
  - `step_exposure_override`: `RefCell<Vec<...>>` → `Mutex<Vec<...>>`
- Evaluator host type
  - `Rc<dyn HostInterface>` → `Arc<dyn HostInterface>`
- Call sites, tests, examples
  - All host constructions and `Evaluator::new/with_environment` invocations updated to pass `Arc` hosts
- Build verification
  - `cargo test --all --no-run` succeeds

### Impact
- Intended as a pure refactor (no functional behavior change).
- External code constructing an evaluator must now pass `Arc<dyn HostInterface>` instead of `Rc`.

### Risks/Notes
- Users with custom test harnesses may need to update `Rc` → `Arc` for host arguments.
- `HostInterface` is not yet explicitly `Send + Sync`; that can be formalized in the next PR.

### How to test
- Build/compile: `cargo test --all --no-run`
- Optional quick runs:
  - `cargo test -p rtfs_compiler --test basic_validation`
  - `cargo test -p rtfs_compiler --test test_simple_recursion`

### Follow-ups
- Implement true parallel `step-parallel` using the thread-safe host.
- Add tests for nested exposure overrides and deterministic merge behavior under concurrency.

### Checklist
- [x] Host internals guarded by `Mutex`
- [x] `Evaluator` updated to `Arc<dyn HostInterface>`
- [x] All call sites/tests/examples migrated to `Arc`
- [x] Compile-only test green in worktree